### PR TITLE
feat: allow list for no-toplevel-side-effect expression statements

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,17 @@ module.exports = {
       };
     },
     'no-toplevel-side-effect': (context)=>({
-      ExpressionStatement:se(context),
+      ExpressionStatement: (node) => {
+        const options = context.options[0] || {};
+
+        const allowedStatements = options.allow || [];
+
+        if (allowedStatements.includes(node.expression.value)) {
+          return;
+        }
+
+        return se(context)(node);
+      },
       IfStatement:se(context),
       ForStatement:se(context),
       WhileStatement:se(context),


### PR DESCRIPTION
This Pull Request enhances the `no-toplevel-side-effect` rule to allow certain statements to be marked as acceptable.

Changes:

- The `no-toplevel-side-effect` rule now accepts an `allow` option in its configuration. This option is a list of statements that are considered acceptable top-level side effects.
- If the expression's value is included in the list of allowed expressions, the rule will not be violated.

Example:

```javascript
module.exports = {
  rules: {
    // see https://react.dev/reference/react/directives
    'no-toplevel-side-effect': ['error', { allow: ['use client', 'use server'] }]
  }
}